### PR TITLE
Gateway parity: wire api-server and multi-adapter runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "tokio-tungstenite 0.24.0",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
  "webpki-roots 0.26.11",
  "wiremock",

--- a/crates/hermes-cli/Cargo.toml
+++ b/crates/hermes-cli/Cargo.toml
@@ -19,7 +19,25 @@ hermes-core = { workspace = true }
 hermes-agent = { workspace = true }
 hermes-tools = { workspace = true }
 hermes-config = { workspace = true }
-hermes-gateway = { workspace = true, features = ["telegram"] }
+hermes-gateway = { workspace = true, features = [
+    "telegram",
+    "discord",
+    "slack",
+    "whatsapp",
+    "signal",
+    "matrix",
+    "mattermost",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "weixin",
+    "bluebubbles",
+    "email",
+    "sms",
+    "homeassistant",
+    "api-server",
+    "webhook",
+] }
 hermes-cron = { workspace = true }
 hermes-environments = { workspace = true }
 hermes-mcp = { workspace = true }

--- a/crates/hermes-cli/src/main.rs
+++ b/crates/hermes-cli/src/main.rs
@@ -28,14 +28,30 @@ use hermes_cron::{
 use hermes_environments::LocalBackend;
 use hermes_gateway::gateway::GatewayConfig as RuntimeGatewayConfig;
 use hermes_gateway::gateway::IncomingMessage as GatewayIncomingMessage;
+use hermes_gateway::platforms::api_server::{ApiInboundRequest, ApiServerAdapter, ApiServerConfig};
+use hermes_gateway::platforms::bluebubbles::{BlueBubblesAdapter, BlueBubblesConfig};
+use hermes_gateway::platforms::dingtalk::{DingTalkAdapter, DingTalkConfig};
+use hermes_gateway::platforms::discord::{DiscordAdapter, DiscordConfig};
+use hermes_gateway::platforms::email::{EmailAdapter, EmailConfig};
+use hermes_gateway::platforms::feishu::{FeishuAdapter, FeishuConfig};
+use hermes_gateway::platforms::homeassistant::{HomeAssistantAdapter, HomeAssistantConfig};
+use hermes_gateway::platforms::matrix::{MatrixAdapter, MatrixConfig};
+use hermes_gateway::platforms::mattermost::{MattermostAdapter, MattermostConfig};
+use hermes_gateway::platforms::signal::{SignalAdapter, SignalConfig};
+use hermes_gateway::platforms::slack::{SlackAdapter, SlackConfig};
+use hermes_gateway::platforms::sms::{SmsAdapter, SmsConfig};
 use hermes_gateway::platforms::telegram::{TelegramAdapter, TelegramConfig};
+use hermes_gateway::platforms::webhook::{WebhookAdapter, WebhookConfig, WebhookPayload};
+use hermes_gateway::platforms::wecom::{WeComAdapter, WeComConfig};
+use hermes_gateway::platforms::weixin::{WeChatAdapter, WeixinConfig};
+use hermes_gateway::platforms::whatsapp::{WhatsAppAdapter, WhatsAppConfig};
 use hermes_gateway::{DmManager, Gateway, GatewayRuntimeContext, SessionManager};
 use hermes_skills::{FileSkillStore, SkillManager};
 use hermes_telemetry::init_telemetry_from_env;
 use hermes_tools::ToolRegistry;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -559,9 +575,502 @@ async fn run_gateway(cli: Cli, action: Option<String>) -> Result<(), AgentError>
                 }
             }
 
+            if let Some(platform_cfg) = config.platforms.get("api-server") {
+                if platform_cfg.enabled {
+                    let api_config = build_api_server_config(platform_cfg);
+                    let api_adapter = Arc::new(ApiServerAdapter::new(api_config.clone()));
+                    let (api_tx, api_rx) = mpsc::channel::<ApiInboundRequest>(256);
+                    api_adapter.set_inbound_sender(api_tx).await;
+                    gateway
+                        .register_adapter("api-server", api_adapter.clone())
+                        .await;
+                    let gw_clone = gateway.clone();
+                    sidecar_tasks.push(tokio::spawn(async move {
+                        run_api_server_inbound_loop(gw_clone, api_rx).await;
+                    }));
+                    println!(
+                        "API server adapter enabled on {}:{}",
+                        api_config.host, api_config.port
+                    );
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("webhook") {
+                if platform_cfg.enabled {
+                    let secret = platform_cfg
+                        .token
+                        .clone()
+                        .filter(|s| !s.trim().is_empty())
+                        .or_else(|| platform_extra_string(platform_cfg, "secret"));
+                    if let Some(secret) = secret {
+                        let webhook_config = build_webhook_config(platform_cfg, secret);
+                        let webhook_adapter = Arc::new(WebhookAdapter::new(webhook_config.clone()));
+                        let (webhook_tx, webhook_rx) = mpsc::channel::<WebhookPayload>(512);
+                        webhook_adapter.set_inbound_sender(webhook_tx).await;
+                        gateway
+                            .register_adapter("webhook", webhook_adapter.clone())
+                            .await;
+                        let gw_clone = gateway.clone();
+                        sidecar_tasks.push(tokio::spawn(async move {
+                            run_webhook_inbound_loop(gw_clone, webhook_rx).await;
+                        }));
+                    } else {
+                        println!(
+                            "Webhook is enabled but secret/token is missing; skipping webhook adapter."
+                        );
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("dingtalk") {
+                if platform_cfg.enabled {
+                    let dingtalk_config = DingTalkConfig::from_platform_config(platform_cfg);
+                    match DingTalkAdapter::new(dingtalk_config.clone()) {
+                        Ok(adapter) => {
+                            let adapter = Arc::new(adapter);
+                            let (tx, rx) = mpsc::channel::<GatewayIncomingMessage>(512);
+                            adapter.set_inbound_sender(tx).await;
+                            gateway.register_adapter("dingtalk", adapter.clone()).await;
+                            let gw_clone = gateway.clone();
+                            sidecar_tasks.push(tokio::spawn(async move {
+                                run_gateway_incoming_loop(gw_clone, rx, "dingtalk").await;
+                            }));
+                        }
+                        Err(err) => {
+                            println!(
+                                "DingTalk is enabled but config is invalid ({err}); skipping."
+                            );
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("weixin") {
+                if platform_cfg.enabled {
+                    let weixin_config = WeixinConfig::from_platform_config(platform_cfg);
+                    match WeChatAdapter::new(weixin_config.clone()) {
+                        Ok(adapter) => {
+                            let adapter = Arc::new(adapter);
+                            let (tx, rx) = mpsc::channel::<GatewayIncomingMessage>(512);
+                            adapter.set_inbound_sender(tx).await;
+                            gateway.register_adapter("weixin", adapter.clone()).await;
+                            let gw_clone = gateway.clone();
+                            sidecar_tasks.push(tokio::spawn(async move {
+                                run_gateway_incoming_loop(gw_clone, rx, "weixin").await;
+                            }));
+                        }
+                        Err(err) => {
+                            println!("Weixin is enabled but config is invalid ({err}); skipping.");
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("discord") {
+                if platform_cfg.enabled {
+                    if let Some(token) = platform_cfg.token.clone().filter(|t| !t.trim().is_empty())
+                    {
+                        let cfg = DiscordConfig {
+                            token,
+                            application_id: platform_extra_string(platform_cfg, "application_id"),
+                            proxy: Default::default(),
+                            require_mention: platform_cfg.require_mention.unwrap_or(false),
+                            intents: platform_extra_u64(platform_cfg, "intents")
+                                .unwrap_or((1 << 0) | (1 << 9) | (1 << 15)),
+                        };
+                        match DiscordAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway
+                                    .register_adapter("discord", Arc::new(adapter))
+                                    .await;
+                            }
+                            Err(err) => println!(
+                                "Discord is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    } else {
+                        println!(
+                            "Discord is enabled but token is missing; skipping discord adapter."
+                        );
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("slack") {
+                if platform_cfg.enabled {
+                    if let Some(token) = platform_cfg.token.clone().filter(|t| !t.trim().is_empty())
+                    {
+                        let cfg = SlackConfig {
+                            token,
+                            app_token: platform_extra_string(platform_cfg, "app_token"),
+                            socket_mode: platform_extra_bool(platform_cfg, "socket_mode")
+                                .unwrap_or(false),
+                            proxy: Default::default(),
+                        };
+                        match SlackAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("slack", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "Slack is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    } else {
+                        println!("Slack is enabled but token is missing; skipping slack adapter.");
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("whatsapp") {
+                if platform_cfg.enabled {
+                    if let Some(token) = platform_cfg.token.clone().filter(|t| !t.trim().is_empty())
+                    {
+                        let cfg = WhatsAppConfig {
+                            token,
+                            phone_number_id: platform_extra_string(platform_cfg, "phone_number_id"),
+                            business_account_id: platform_extra_string(
+                                platform_cfg,
+                                "business_account_id",
+                            ),
+                            verify_token: platform_extra_string(platform_cfg, "verify_token"),
+                            proxy: Default::default(),
+                        };
+                        match WhatsAppAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway
+                                    .register_adapter("whatsapp", Arc::new(adapter))
+                                    .await;
+                            }
+                            Err(err) => println!(
+                                "WhatsApp is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    } else {
+                        println!(
+                            "WhatsApp is enabled but token is missing; skipping whatsapp adapter."
+                        );
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("signal") {
+                if platform_cfg.enabled {
+                    let phone_number = platform_extra_string(platform_cfg, "phone_number")
+                        .or_else(|| platform_cfg.token.clone())
+                        .unwrap_or_default();
+                    if phone_number.trim().is_empty() {
+                        println!(
+                            "Signal is enabled but phone_number/token is missing; skipping signal adapter."
+                        );
+                    } else {
+                        let cfg = SignalConfig {
+                            phone_number,
+                            api_url: platform_extra_string(platform_cfg, "api_url")
+                                .unwrap_or_else(|| "http://localhost:8080".to_string()),
+                            proxy: Default::default(),
+                        };
+                        match SignalAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("signal", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "Signal is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("matrix") {
+                if platform_cfg.enabled {
+                    let homeserver_url =
+                        platform_extra_string(platform_cfg, "homeserver_url").unwrap_or_default();
+                    let user_id =
+                        platform_extra_string(platform_cfg, "user_id").unwrap_or_default();
+                    let access_token = platform_cfg.token.clone().unwrap_or_default();
+                    if homeserver_url.trim().is_empty()
+                        || user_id.trim().is_empty()
+                        || access_token.trim().is_empty()
+                    {
+                        println!(
+                            "Matrix is enabled but homeserver_url/user_id/token is missing; skipping matrix adapter."
+                        );
+                    } else {
+                        let cfg = MatrixConfig {
+                            homeserver_url,
+                            user_id,
+                            access_token,
+                            room_id: platform_extra_string(platform_cfg, "room_id"),
+                            proxy: Default::default(),
+                        };
+                        match MatrixAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("matrix", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "Matrix is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("mattermost") {
+                if platform_cfg.enabled {
+                    let server_url =
+                        platform_extra_string(platform_cfg, "server_url").unwrap_or_default();
+                    let token = platform_cfg.token.clone().unwrap_or_default();
+                    if server_url.trim().is_empty() || token.trim().is_empty() {
+                        println!(
+                            "Mattermost is enabled but server_url/token is missing; skipping mattermost adapter."
+                        );
+                    } else {
+                        let cfg = MattermostConfig {
+                            server_url,
+                            token,
+                            team_id: platform_extra_string(platform_cfg, "team_id"),
+                            proxy: Default::default(),
+                        };
+                        match MattermostAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway
+                                    .register_adapter("mattermost", Arc::new(adapter))
+                                    .await;
+                            }
+                            Err(err) => println!(
+                                "Mattermost is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("feishu") {
+                if platform_cfg.enabled {
+                    let app_id = platform_extra_string(platform_cfg, "app_id").unwrap_or_default();
+                    let app_secret =
+                        platform_extra_string(platform_cfg, "app_secret").unwrap_or_default();
+                    if app_id.trim().is_empty() || app_secret.trim().is_empty() {
+                        println!(
+                            "Feishu is enabled but app_id/app_secret is missing; skipping feishu adapter."
+                        );
+                    } else {
+                        let cfg = FeishuConfig {
+                            app_id,
+                            app_secret,
+                            verification_token: platform_extra_string(
+                                platform_cfg,
+                                "verification_token",
+                            ),
+                            encrypt_key: platform_extra_string(platform_cfg, "encrypt_key"),
+                            proxy: Default::default(),
+                        };
+                        match FeishuAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("feishu", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "Feishu is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("wecom") {
+                if platform_cfg.enabled {
+                    let corp_id =
+                        platform_extra_string(platform_cfg, "corp_id").unwrap_or_default();
+                    let agent_id =
+                        platform_extra_string(platform_cfg, "agent_id").unwrap_or_default();
+                    let secret = platform_extra_string(platform_cfg, "secret").unwrap_or_default();
+                    if corp_id.trim().is_empty()
+                        || agent_id.trim().is_empty()
+                        || secret.trim().is_empty()
+                    {
+                        println!(
+                            "WeCom is enabled but corp_id/agent_id/secret is missing; skipping wecom adapter."
+                        );
+                    } else {
+                        let cfg = WeComConfig {
+                            corp_id,
+                            agent_id,
+                            secret,
+                            proxy: Default::default(),
+                        };
+                        match WeComAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("wecom", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "WeCom is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("bluebubbles") {
+                if platform_cfg.enabled {
+                    let server_url =
+                        platform_extra_string(platform_cfg, "server_url").unwrap_or_default();
+                    let password = platform_cfg
+                        .token
+                        .clone()
+                        .filter(|s| !s.trim().is_empty())
+                        .or_else(|| platform_extra_string(platform_cfg, "password"))
+                        .unwrap_or_default();
+                    if server_url.trim().is_empty() || password.trim().is_empty() {
+                        println!(
+                            "BlueBubbles is enabled but server_url/password is missing; skipping bluebubbles adapter."
+                        );
+                    } else {
+                        let cfg = BlueBubblesConfig {
+                            server_url,
+                            password,
+                            proxy: Default::default(),
+                        };
+                        match BlueBubblesAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway
+                                    .register_adapter("bluebubbles", Arc::new(adapter))
+                                    .await;
+                            }
+                            Err(err) => println!(
+                                "BlueBubbles is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("email") {
+                if platform_cfg.enabled {
+                    let imap_host =
+                        platform_extra_string(platform_cfg, "imap_host").unwrap_or_default();
+                    let smtp_host =
+                        platform_extra_string(platform_cfg, "smtp_host").unwrap_or_default();
+                    let username =
+                        platform_extra_string(platform_cfg, "username").unwrap_or_default();
+                    let password = platform_cfg
+                        .token
+                        .clone()
+                        .filter(|s| !s.trim().is_empty())
+                        .or_else(|| platform_extra_string(platform_cfg, "password"))
+                        .unwrap_or_default();
+                    if imap_host.trim().is_empty()
+                        || smtp_host.trim().is_empty()
+                        || username.trim().is_empty()
+                        || password.trim().is_empty()
+                    {
+                        println!(
+                            "Email is enabled but imap_host/smtp_host/username/password is missing; skipping email adapter."
+                        );
+                    } else {
+                        let cfg = EmailConfig {
+                            imap_host,
+                            imap_port: platform_extra_u16(platform_cfg, "imap_port").unwrap_or(993),
+                            smtp_host,
+                            smtp_port: platform_extra_u16(platform_cfg, "smtp_port").unwrap_or(587),
+                            username,
+                            password,
+                            poll_interval_secs: platform_extra_u64(
+                                platform_cfg,
+                                "poll_interval_secs",
+                            )
+                            .unwrap_or(60),
+                            proxy: Default::default(),
+                        };
+                        match EmailAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("email", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "Email is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("sms") {
+                if platform_cfg.enabled {
+                    let account_sid =
+                        platform_extra_string(platform_cfg, "account_sid").unwrap_or_default();
+                    let auth_token = platform_cfg
+                        .token
+                        .clone()
+                        .filter(|s| !s.trim().is_empty())
+                        .or_else(|| platform_extra_string(platform_cfg, "auth_token"))
+                        .unwrap_or_default();
+                    let from_number =
+                        platform_extra_string(platform_cfg, "from_number").unwrap_or_default();
+                    if account_sid.trim().is_empty()
+                        || auth_token.trim().is_empty()
+                        || from_number.trim().is_empty()
+                    {
+                        println!(
+                            "SMS is enabled but account_sid/auth_token/from_number is missing; skipping sms adapter."
+                        );
+                    } else {
+                        let cfg = SmsConfig {
+                            provider: platform_extra_string(platform_cfg, "provider")
+                                .unwrap_or_else(|| "twilio".to_string()),
+                            account_sid,
+                            auth_token,
+                            from_number,
+                            proxy: Default::default(),
+                        };
+                        match SmsAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway.register_adapter("sms", Arc::new(adapter)).await;
+                            }
+                            Err(err) => println!(
+                                "SMS is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
+            if let Some(platform_cfg) = config.platforms.get("homeassistant") {
+                if platform_cfg.enabled {
+                    let base_url =
+                        platform_extra_string(platform_cfg, "base_url").unwrap_or_default();
+                    let long_lived_token = platform_cfg
+                        .token
+                        .clone()
+                        .filter(|s| !s.trim().is_empty())
+                        .or_else(|| platform_extra_string(platform_cfg, "long_lived_token"))
+                        .unwrap_or_default();
+                    if base_url.trim().is_empty() || long_lived_token.trim().is_empty() {
+                        println!(
+                            "HomeAssistant is enabled but base_url/long_lived_token is missing; skipping homeassistant adapter."
+                        );
+                    } else {
+                        let cfg = HomeAssistantConfig {
+                            base_url,
+                            long_lived_token,
+                            webhook_id: platform_extra_string(platform_cfg, "webhook_id"),
+                            proxy: Default::default(),
+                        };
+                        match HomeAssistantAdapter::new(cfg) {
+                            Ok(adapter) => {
+                                gateway
+                                    .register_adapter("homeassistant", Arc::new(adapter))
+                                    .await;
+                            }
+                            Err(err) => println!(
+                                "HomeAssistant is enabled but could not initialize adapter ({err}); skipping."
+                            ),
+                        }
+                    }
+                }
+            }
+
             if gateway.adapter_names().await.is_empty() {
                 println!(
-                    "No chat adapters started (e.g. missing Telegram token). Cron + webhooks still active."
+                    "No platform adapters started (e.g. missing required platform config). Cron + webhook delivery still active."
                 );
             }
 
@@ -745,6 +1254,128 @@ fn build_telegram_config(
         parse_html,
         poll_timeout,
         bot_username: None,
+    }
+}
+
+fn build_api_server_config(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+) -> ApiServerConfig {
+    ApiServerConfig {
+        host: platform_extra_string(platform_cfg, "host").unwrap_or_else(|| "0.0.0.0".to_string()),
+        port: platform_extra_u16(platform_cfg, "port").unwrap_or(8090),
+        auth_token: platform_cfg
+            .token
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| platform_extra_string(platform_cfg, "auth_token")),
+    }
+}
+
+fn build_webhook_config(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    secret: String,
+) -> WebhookConfig {
+    WebhookConfig {
+        port: platform_extra_u16(platform_cfg, "port").unwrap_or(9000),
+        path: platform_extra_string(platform_cfg, "path").unwrap_or_else(|| "/webhook".to_string()),
+        secret,
+    }
+}
+
+fn platform_extra_string(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+) -> Option<String> {
+    platform_cfg
+        .extra
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+fn platform_extra_u16(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+) -> Option<u16> {
+    platform_cfg
+        .extra
+        .get(key)
+        .and_then(|v| v.as_u64())
+        .and_then(|v| u16::try_from(v).ok())
+}
+
+fn platform_extra_u64(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+) -> Option<u64> {
+    platform_cfg.extra.get(key).and_then(|v| v.as_u64())
+}
+
+fn platform_extra_bool(
+    platform_cfg: &hermes_config::platform::PlatformConfig,
+    key: &str,
+) -> Option<bool> {
+    platform_cfg.extra.get(key).and_then(|v| v.as_bool())
+}
+
+async fn run_api_server_inbound_loop(
+    gateway: Arc<Gateway>,
+    mut rx: mpsc::Receiver<ApiInboundRequest>,
+) {
+    while let Some(req) = rx.recv().await {
+        gateway
+            .merge_request_runtime_overrides(
+                "api-server",
+                &req.session_id,
+                &req.user_id,
+                req.model.clone(),
+                req.provider.clone(),
+                req.personality.clone(),
+            )
+            .await;
+        let incoming = GatewayIncomingMessage {
+            platform: "api-server".to_string(),
+            chat_id: req.session_id.clone(),
+            user_id: req.user_id.clone(),
+            text: req.prompt.clone(),
+            message_id: Some(req.request_id.clone()),
+            is_dm: true,
+        };
+        if let Err(err) = gateway.route_message(&incoming).await {
+            tracing::warn!("Failed to route api-server message: {}", err);
+        }
+    }
+}
+
+async fn run_webhook_inbound_loop(gateway: Arc<Gateway>, mut rx: mpsc::Receiver<WebhookPayload>) {
+    while let Some(payload) = rx.recv().await {
+        let incoming = GatewayIncomingMessage {
+            platform: "webhook".to_string(),
+            chat_id: payload.chat_id,
+            user_id: payload
+                .user_id
+                .unwrap_or_else(|| "webhook-client".to_string()),
+            text: payload.text,
+            message_id: None,
+            is_dm: true,
+        };
+        if let Err(err) = gateway.route_message(&incoming).await {
+            tracing::warn!("Failed to route webhook message: {}", err);
+        }
+    }
+}
+
+async fn run_gateway_incoming_loop(
+    gateway: Arc<Gateway>,
+    mut rx: mpsc::Receiver<GatewayIncomingMessage>,
+    platform: &'static str,
+) {
+    while let Some(incoming) = rx.recv().await {
+        if let Err(err) = gateway.route_message(&incoming).await {
+            tracing::warn!("Failed to route {} message: {}", platform, err);
+        }
     }
 }
 

--- a/crates/hermes-gateway/Cargo.toml
+++ b/crates/hermes-gateway/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { workspace = true }
 url = { workspace = true }
 futures = { workspace = true }
 regex = { workspace = true }
+urlencoding = "2"
 md5 = "0.7"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 webpki-roots = "0.26"

--- a/crates/hermes-gateway/src/platforms/api_server.rs
+++ b/crates/hermes-gateway/src/platforms/api_server.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,14 @@ pub struct ChatCompletionRequest {
     pub messages: Vec<ChatMessage>,
     #[serde(default)]
     pub stream: bool,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub personality: Option<String>,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f64>,
 }
@@ -129,6 +138,17 @@ pub struct ApiError {
     pub code: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct ApiInboundRequest {
+    pub request_id: String,
+    pub session_id: String,
+    pub user_id: String,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub personality: Option<String>,
+    pub prompt: String,
+}
+
 // ---------------------------------------------------------------------------
 // Pending response mailbox
 // ---------------------------------------------------------------------------
@@ -149,6 +169,7 @@ pub struct ApiServerAdapter {
     stop_signal: Arc<Notify>,
     shutdown_tx: RwLock<Option<tokio::sync::oneshot::Sender<()>>>,
     mailbox: Arc<RwLock<ResponseMailbox>>,
+    inbound_tx: Arc<RwLock<Option<mpsc::Sender<ApiInboundRequest>>>>,
 }
 
 impl ApiServerAdapter {
@@ -165,11 +186,16 @@ impl ApiServerAdapter {
             stop_signal: Arc::new(Notify::new()),
             shutdown_tx: RwLock::new(None),
             mailbox: Arc::new(RwLock::new(ResponseMailbox::default())),
+            inbound_tx: Arc::new(RwLock::new(None)),
         }
     }
 
     pub fn config(&self) -> &ApiServerConfig {
         &self.config
+    }
+
+    pub async fn set_inbound_sender(&self, tx: mpsc::Sender<ApiInboundRequest>) {
+        *self.inbound_tx.write().await = Some(tx);
     }
 
     fn make_completion_id() -> String {
@@ -251,6 +277,7 @@ impl PlatformAdapter for ApiServerAdapter {
             .map_err(|e| GatewayError::ConnectionFailed(format!("Invalid address: {e}")))?;
 
         let mailbox = self.mailbox.clone();
+        let inbound_tx = self.inbound_tx.clone();
         let auth_token = self.config.auth_token.clone();
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -278,9 +305,12 @@ impl PlatformAdapter for ApiServerAdapter {
                         match accept {
                             Ok((stream, peer)) => {
                                 let mailbox = mailbox.clone();
+                                let inbound_tx = inbound_tx.clone();
                                 let auth_token = auth_token.clone();
                                 tokio::spawn(async move {
-                                    if let Err(e) = handle_connection(stream, peer, mailbox, auth_token).await {
+                                    if let Err(e) =
+                                        handle_connection(stream, peer, mailbox, inbound_tx, auth_token).await
+                                    {
                                         debug!("API connection error from {peer}: {e}");
                                     }
                                 });
@@ -365,26 +395,38 @@ impl PlatformAdapter for ApiServerAdapter {
 async fn handle_connection(
     stream: tokio::net::TcpStream,
     _peer: SocketAddr,
-    _mailbox: Arc<RwLock<ResponseMailbox>>,
+    mailbox: Arc<RwLock<ResponseMailbox>>,
+    inbound_tx: Arc<RwLock<Option<mpsc::Sender<ApiInboundRequest>>>>,
     auth_token: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncWriteExt;
 
-    let mut buf = vec![0u8; 65536];
     let (mut reader, mut writer) = stream.into_split();
-    let n = reader.read(&mut buf).await?;
-    if n == 0 {
+    let raw = read_http_request(&mut reader).await?;
+    if raw.is_empty() {
         return Ok(());
     }
 
-    let request = String::from_utf8_lossy(&buf[..n]);
-    let first_line = request.lines().next().unwrap_or("");
+    let Some(header_end) = find_bytes(&raw, b"\r\n\r\n") else {
+        let body = r#"{"error":{"message":"Invalid HTTP request","type":"invalid_request_error","code":"400"}}"#;
+        let resp = format!(
+            "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        writer.write_all(resp.as_bytes()).await?;
+        return Ok(());
+    };
+
+    let header_text = String::from_utf8_lossy(&raw[..header_end]);
+    let body_bytes = &raw[(header_end + 4).min(raw.len())..];
+    let first_line = header_text.lines().next().unwrap_or("");
     let parts: Vec<&str> = first_line.split_whitespace().collect();
     let method = parts.first().copied().unwrap_or("GET");
     let path = parts.get(1).copied().unwrap_or("/");
 
     // Extract Authorization header
-    let auth_header = request
+    let auth_header = header_text
         .lines()
         .find(|l| l.to_lowercase().starts_with("authorization:"))
         .map(|l| l.splitn(2, ':').nth(1).unwrap_or("").trim().to_string());
@@ -409,22 +451,146 @@ async fn handle_connection(
 
     match (method, path) {
         ("POST", "/v1/chat/completions") | ("POST", "/v1/responses") => {
-            let body_start = request.find("\r\n\r\n").map(|i| i + 4).unwrap_or(n);
-            let body_str = &request[body_start..];
+            let body_str = String::from_utf8_lossy(body_bytes);
 
-            let parsed: Result<ChatCompletionRequest, _> = serde_json::from_str(body_str);
+            let parsed: Result<ChatCompletionRequest, _> = serde_json::from_str(&body_str);
             match parsed {
                 Ok(req) => {
                     let request_id = ApiServerAdapter::make_completion_id();
                     let model = req.model.as_deref().unwrap_or("hermes").to_string();
-                    let last_msg = req
-                        .messages
-                        .last()
-                        .map(|m| m.content.clone())
-                        .unwrap_or_default();
+                    let prompt = extract_latest_user_prompt(&req.messages).unwrap_or_default();
+                    if prompt.trim().is_empty() {
+                        let err = serde_json::json!({
+                            "error": {
+                                "message": "Request must include at least one user message",
+                                "type":"invalid_request_error",
+                                "code":"400"
+                            }
+                        });
+                        let body = serde_json::to_string(&err)?;
+                        let resp = format!(
+                            "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        writer.write_all(resp.as_bytes()).await?;
+                        return Ok(());
+                    }
 
-                    // Echo back with a placeholder response for now
-                    let reply = format!("Received: {}", last_msg);
+                    let session_id = req.session_id.unwrap_or_else(|| request_id.clone());
+                    let mailbox_key = session_id.clone();
+                    let user_id = req
+                        .user
+                        .filter(|u| !u.trim().is_empty())
+                        .unwrap_or_else(|| "api-client".to_string());
+                    let inbound = ApiInboundRequest {
+                        request_id: request_id.clone(),
+                        session_id,
+                        user_id,
+                        model: req.model.clone(),
+                        provider: req.provider.clone(),
+                        personality: req.personality.clone(),
+                        prompt,
+                    };
+
+                    let (reply_tx, mut reply_rx) = mpsc::channel::<String>(1);
+                    {
+                        let mut guard = mailbox.write().await;
+                        guard.pending.insert(mailbox_key.clone(), reply_tx);
+                    }
+
+                    let maybe_inbound = inbound_tx.read().await.clone();
+                    let Some(tx) = maybe_inbound else {
+                        let mut guard = mailbox.write().await;
+                        guard.pending.remove(&mailbox_key);
+                        let err = serde_json::json!({
+                            "error": {
+                                "message":"Gateway inbound pipeline is not configured",
+                                "type":"service_unavailable",
+                                "code":"503"
+                            }
+                        });
+                        let body = serde_json::to_string(&err)?;
+                        let resp = format!(
+                            "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        writer.write_all(resp.as_bytes()).await?;
+                        return Ok(());
+                    };
+
+                    if tx.send(inbound).await.is_err() {
+                        let mut guard = mailbox.write().await;
+                        guard.pending.remove(&mailbox_key);
+                        let err = serde_json::json!({
+                            "error": {
+                                "message":"Gateway inbound queue is unavailable",
+                                "type":"service_unavailable",
+                                "code":"503"
+                            }
+                        });
+                        let body = serde_json::to_string(&err)?;
+                        let resp = format!(
+                            "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        writer.write_all(resp.as_bytes()).await?;
+                        return Ok(());
+                    }
+
+                    let reply = match tokio::time::timeout(
+                        Duration::from_secs(120),
+                        reply_rx.recv(),
+                    )
+                    .await
+                    {
+                        Ok(Some(msg)) => msg,
+                        Ok(None) => {
+                            let err = serde_json::json!({
+                                "error": {
+                                    "message":"Gateway closed response channel",
+                                    "type":"internal_error",
+                                    "code":"502"
+                                }
+                            });
+                            let body = serde_json::to_string(&err)?;
+                            let resp = format!(
+                                "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                                body.len(),
+                                body
+                            );
+                            writer.write_all(resp.as_bytes()).await?;
+                            let mut guard = mailbox.write().await;
+                            guard.pending.remove(&mailbox_key);
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            let err = serde_json::json!({
+                                "error": {
+                                    "message":"Gateway response timeout",
+                                    "type":"timeout_error",
+                                    "code":"504"
+                                }
+                            });
+                            let body = serde_json::to_string(&err)?;
+                            let resp = format!(
+                                "HTTP/1.1 504 Gateway Timeout\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                                body.len(),
+                                body
+                            );
+                            writer.write_all(resp.as_bytes()).await?;
+                            let mut guard = mailbox.write().await;
+                            guard.pending.remove(&mailbox_key);
+                            return Ok(());
+                        }
+                    };
+
+                    {
+                        let mut guard = mailbox.write().await;
+                        guard.pending.remove(&mailbox_key);
+                    }
 
                     if req.stream {
                         let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n";
@@ -502,4 +668,105 @@ async fn handle_connection(
     }
 
     Ok(())
+}
+
+fn extract_latest_user_prompt(messages: &[ChatMessage]) -> Option<String> {
+    messages
+        .iter()
+        .rev()
+        .find(|m| m.role.eq_ignore_ascii_case("user"))
+        .map(|m| m.content.clone())
+        .or_else(|| messages.last().map(|m| m.content.clone()))
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+fn parse_content_length(headers: &str) -> usize {
+    headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0)
+}
+
+async fn read_http_request(
+    reader: &mut tokio::net::tcp::OwnedReadHalf,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    use tokio::io::AsyncReadExt;
+
+    let mut buf = Vec::with_capacity(16 * 1024);
+    let mut chunk = [0_u8; 8192];
+    let mut expected_total: Option<usize> = None;
+
+    loop {
+        let n = reader.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.len() > 2 * 1024 * 1024 {
+            break;
+        }
+
+        if expected_total.is_none() {
+            if let Some(header_end) = find_bytes(&buf, b"\r\n\r\n") {
+                let header_text = String::from_utf8_lossy(&buf[..header_end]);
+                let body_len = parse_content_length(&header_text);
+                expected_total = Some(header_end + 4 + body_len);
+            }
+        }
+        if let Some(total) = expected_total {
+            if buf.len() >= total {
+                break;
+            }
+        }
+    }
+
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_content_length_is_case_insensitive() {
+        let h = "POST /x HTTP/1.1\r\nHost: localhost\r\nContent-Length: 42\r\n\r\n";
+        assert_eq!(parse_content_length(h), 42);
+        let h2 = "POST /x HTTP/1.1\r\ncontent-length: 9\r\n\r\n";
+        assert_eq!(parse_content_length(h2), 9);
+    }
+
+    #[test]
+    fn extract_latest_user_prompt_prefers_user_role() {
+        let msgs = vec![
+            ChatMessage {
+                role: "system".into(),
+                content: "rules".into(),
+            },
+            ChatMessage {
+                role: "assistant".into(),
+                content: "hello".into(),
+            },
+            ChatMessage {
+                role: "user".into(),
+                content: "final prompt".into(),
+            },
+        ];
+        assert_eq!(
+            extract_latest_user_prompt(&msgs).as_deref(),
+            Some("final prompt")
+        );
+    }
 }

--- a/crates/hermes-gateway/src/platforms/discord.rs
+++ b/crates/hermes-gateway/src/platforms/discord.rs
@@ -956,7 +956,7 @@ impl DiscordAdapter {
         commands: &[SlashCommand],
     ) -> Result<(), GatewayError> {
         let app_id = self.config.application_id.as_deref().ok_or_else(|| {
-            GatewayError::ConfigError("application_id required for slash commands".into())
+            GatewayError::Platform("application_id required for slash commands".into())
         })?;
 
         let url = format!("{}/applications/{}/commands", DISCORD_API_BASE, app_id);
@@ -993,7 +993,7 @@ impl DiscordAdapter {
         commands: &[SlashCommand],
     ) -> Result<(), GatewayError> {
         let app_id = self.config.application_id.as_deref().ok_or_else(|| {
-            GatewayError::ConfigError("application_id required for slash commands".into())
+            GatewayError::Platform("application_id required for slash commands".into())
         })?;
 
         let url = format!(

--- a/crates/hermes-gateway/src/platforms/slack.rs
+++ b/crates/hermes-gateway/src/platforms/slack.rs
@@ -156,7 +156,7 @@ pub struct SlackEvent {
 }
 
 /// Incoming message parsed from a Slack event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncomingSlackMessage {
     pub channel: String,
     pub user_id: Option<String>,


### PR DESCRIPTION
## Summary
This PR closes most of the gateway-parity gap between the current Rust gateway runtime and the full Hermes product backend wiring.

### What changed
- Enabled broad adapter feature coverage in `hermes-cli` dependency on `hermes-gateway`:
  - `telegram`, `discord`, `slack`, `whatsapp`, `signal`, `matrix`, `mattermost`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `email`, `sms`, `homeassistant`, `api-server`, `webhook`.
- Refactored `hermes gateway start` runtime wiring:
  - Registers enabled adapters from `config.platforms`.
  - Adds config extraction from `PlatformConfig.extra` for adapter-specific fields.
  - Adds inbound workers for adapters that expose inbound channels:
    - `api-server`
    - `webhook`
    - `dingtalk`
    - `weixin`
- Upgraded `ApiServerAdapter` from placeholder echo behavior to real gateway-backed flow:
  - Adds `ApiInboundRequest` channel.
  - Correlates request/response through mailbox keys.
  - Supports runtime override hints (`model`, `provider`, `personality`).
  - Returns structured HTTP errors for unavailable pipeline and response timeout paths.
- Added `api-server` unit tests for header parsing and prompt extraction.

### Build-fix follow-through from feature expansion
- Fixed pre-existing compile blockers exposed by enabling full adapter features:
  - Discord `GatewayError::ConfigError` -> `GatewayError::Platform`.
  - Slack incoming message equality derives for `SocketModeAction`.
  - Added `urlencoding` dependency needed by Matrix adapter code path.

## Validation
- `cargo check -p hermes-cli`
- `cargo test -p hermes-gateway --features "api-server" extract_latest_user_prompt_prefers_user_role -- --nocapture`
- `cargo test -p hermes-gateway --features "api-server dingtalk" parse_content_length_is_case_insensitive -- --nocapture`
- `cargo test -p hermes-gateway --features "api-server dingtalk" build_ack_shape_matches_stream_contract -- --nocapture`

## Known limits / follow-ups
- This brings runtime wiring close to full-product behavior but does not invent missing adapter upstream capabilities (e.g. Matrix E2EE placeholder caveat remains).
- `api-server` currently routes latest user message per request through gateway session correlation; fully lossless OpenAI multi-message replay semantics are still a follow-up.

Closes sheawinkler/hermes-agent-ultra#53
